### PR TITLE
air data 조회 개선

### DIFF
--- a/src/main/kotlin/com/example/front/dashboard/client/AirDataClient.java
+++ b/src/main/kotlin/com/example/front/dashboard/client/AirDataClient.java
@@ -1,25 +1,25 @@
 package com.example.front.dashboard.client;
 
+import com.example.front.dashboard.model.DashboardSearchDto;
 import com.example.front.dashboard.service.AbstractApiCallResponseTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.util.Map;
 
 @Component
-public class AirDataClient extends AbstractApiCallResponseTemplate {
+public class AirDataClient extends AbstractApiCallResponseTemplate<DashboardSearchDto> {
     private final static Logger LOGGER = LoggerFactory.getLogger(AirDataClient.class);
 
     @Value("${api.call.url}")
     private String RESOURCE;
 
     @Override
-    public String urlMake(Map params) {
+    public String urlMake(DashboardSearchDto params) {
         String callUrl = "";
-        if(!params.isEmpty()){
-            callUrl = RESOURCE +"airs/"+ params.get("startDate")+"/"+params.get("endDate")+"/"+params.get("stationName");
+        if(params != null){
+            callUrl = RESOURCE +"airs/"+ params.getStartDate()+"/"+params.getEndDate()+"/"+params.getStationName();
         }
         return callUrl;
     }

--- a/src/main/kotlin/com/example/front/dashboard/config/PropertyEncyptConfiguration.java
+++ b/src/main/kotlin/com/example/front/dashboard/config/PropertyEncyptConfiguration.java
@@ -4,7 +4,6 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
 
 @Configuration
 public class PropertyEncyptConfiguration {

--- a/src/main/kotlin/com/example/front/dashboard/controller/DashboardController.java
+++ b/src/main/kotlin/com/example/front/dashboard/controller/DashboardController.java
@@ -24,15 +24,15 @@ public class DashboardController {
     private DashboardService service;
 
     @GetMapping("")
-    public ModelAndView index(@Valid @ModelAttribute DashboardSearchDto dashboardSearchDto, BindingResult bindingResult){
+    public ModelAndView index(@Valid @ModelAttribute DashboardSearchDto params, BindingResult bindingResult){
         ModelAndView modelAndView = new ModelAndView();
         modelAndView.setViewName("dashBoard");
         Map<String, Object> map = new HashMap<>();
         map.put("station",service.getStationNames());
 
-        if("Y".equals(dashboardSearchDto.getIsSearch())){
-            service.ValidDashboardSearch(dashboardSearchDto);
-
+        if("Y".equals(params.getIsSearch())){
+            service.ValidDashboardSearch(params);
+            map.put("air",service.GetAirData(params));
         }
 
         modelAndView.addObject("data", map);

--- a/src/main/kotlin/com/example/front/dashboard/controller/DashboardDataController.java
+++ b/src/main/kotlin/com/example/front/dashboard/controller/DashboardDataController.java
@@ -1,0 +1,11 @@
+package com.example.front.dashboard.controller;
+
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/data")
+@AllArgsConstructor
+public class DashboardDataController {
+}

--- a/src/main/kotlin/com/example/front/dashboard/model/AirData.java
+++ b/src/main/kotlin/com/example/front/dashboard/model/AirData.java
@@ -1,4 +1,58 @@
 package com.example.front.dashboard.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
 public class AirData {
+
+    private Long seq;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime dataTime;
+
+    private Double so2Value;
+
+    private Double coValue;
+
+    private Double o3Value;
+
+    private Double no2Value;
+
+    private Double pm10Value;
+
+    private Double pm10value24;
+
+    private Double pm25Value;
+
+    private Double pm25Value24;
+
+    private Double khaiValue;
+
+    private Double khaiGrade;
+
+    private Double so2Grade;
+
+    private Double coGrade;
+
+    private Double o3Grade;
+
+    private Double no2Grade;
+
+    private Double pm10Grade;
+
+    private Double pm25Grade;
+
+    private Double pm10Grade1h;
+
+    private Double pm25Grade1h;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime regdate;
+
+    private String stationName;
 }

--- a/src/main/kotlin/com/example/front/dashboard/model/AirDataSearch.java
+++ b/src/main/kotlin/com/example/front/dashboard/model/AirDataSearch.java
@@ -1,0 +1,4 @@
+package com.example.front.dashboard.model;
+
+public class AirDataSearch {
+}

--- a/src/main/kotlin/com/example/front/dashboard/model/DashboardSearchDto.java
+++ b/src/main/kotlin/com/example/front/dashboard/model/DashboardSearchDto.java
@@ -2,7 +2,6 @@ package com.example.front.dashboard.model;
 
 import lombok.Getter;
 import lombok.Setter;
-import javax.validation.constraints.*;
 
 @Getter
 @Setter

--- a/src/main/kotlin/com/example/front/dashboard/service/AbstractApiCallResponseTemplate.java
+++ b/src/main/kotlin/com/example/front/dashboard/service/AbstractApiCallResponseTemplate.java
@@ -10,7 +10,7 @@ import org.springframework.web.client.RestTemplate;
 import java.util.List;
 import java.util.Map;
 
-public abstract class AbstractApiCallResponseTemplate implements ApiCallResponseTemplate{
+public abstract class AbstractApiCallResponseTemplate<T> implements ApiCallResponseTemplate{
 
     @Override
     public List getList(String url) {
@@ -21,5 +21,5 @@ public abstract class AbstractApiCallResponseTemplate implements ApiCallResponse
         return null;
     }
 
-    public abstract String urlMake(Map params);
+    public abstract String urlMake(T params);
 }

--- a/src/main/kotlin/com/example/front/dashboard/service/AbstractApiCallResponseTemplate.java
+++ b/src/main/kotlin/com/example/front/dashboard/service/AbstractApiCallResponseTemplate.java
@@ -1,5 +1,6 @@
 package com.example.front.dashboard.service;
 
+import com.example.front.dashboard.model.AirData;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -13,12 +14,13 @@ import java.util.Map;
 public abstract class AbstractApiCallResponseTemplate<T> implements ApiCallResponseTemplate{
 
     @Override
-    public List getList(String url) {
+    public ResponseEntity<AirData> getList(String url) {
         RestTemplate restTemplate = new RestTemplate();
         HttpHeaders header = new HttpHeaders();
         HttpEntity<?> entity = new HttpEntity<>(header);
-        ResponseEntity<Map> resultMap = restTemplate.exchange(url, HttpMethod.GET, entity, Map.class);
-        return null;
+        ResponseEntity<AirData> resultMap = restTemplate.exchange(url, HttpMethod.GET, entity, AirData.class);
+
+        return resultMap;
     }
 
     public abstract String urlMake(T params);

--- a/src/main/kotlin/com/example/front/dashboard/service/AirDataResponse.java
+++ b/src/main/kotlin/com/example/front/dashboard/service/AirDataResponse.java
@@ -1,19 +1,25 @@
 package com.example.front.dashboard.service;
 
+import com.example.front.dashboard.model.AirData;
+import com.example.front.dashboard.model.DashboardSearchDto;
 import lombok.AllArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
-import java.util.Map;
+import java.util.List;
 
 @Component
 @AllArgsConstructor
 public class AirDataResponse {
     private ApiCallResponseFactory apiCallResponseFactory;
 
-    public Map<String, Object> getList(Map<String, Object> params){
+    @Cacheable(value = "getAirDataList" , keyGenerator = "customerGenerator")
+    public List<AirData> getList(DashboardSearchDto params){
         AbstractApiCallResponseTemplate client = apiCallResponseFactory.getClient(ClientType.AIRDATA_TYPE.getApiTypeCode());
 
         String callUrl = client.urlMake(params);
+        ResponseEntity<AirData> response = client.getList(callUrl);
 
         return null;
     }

--- a/src/main/kotlin/com/example/front/dashboard/service/ApiCallResponseTemplate.java
+++ b/src/main/kotlin/com/example/front/dashboard/service/ApiCallResponseTemplate.java
@@ -1,8 +1,11 @@
 package com.example.front.dashboard.service;
 
+import com.example.front.dashboard.model.AirData;
+import org.springframework.http.ResponseEntity;
+
 import java.util.List;
 import java.util.Map;
 
 public interface ApiCallResponseTemplate<T> {
-    List<T> getList(String url);
+    ResponseEntity<T> getList(String url);
 }

--- a/src/main/kotlin/com/example/front/dashboard/service/DashboardService.java
+++ b/src/main/kotlin/com/example/front/dashboard/service/DashboardService.java
@@ -7,8 +7,6 @@ import com.example.front.dashboard.model.DashboardSearchDto;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 
 import java.util.Arrays;
 import java.util.List;
@@ -29,9 +27,9 @@ public class DashboardService {
         return lists;
     }
 
-    /*public List<AirData> GetAirData(DashboardSearchDto dto){
-        airDataResponse.getList()
-    }*/
+    public List<AirData> GetAirData(DashboardSearchDto params){
+        return airDataResponse.getList(params);
+    }
 
     public void ValidDashboardSearch(DashboardSearchDto dto){
         if(dto.getStartDate() == null || dto.getStartDate() == ""){

--- a/src/main/kotlin/com/example/front/dashboard/service/DashboardService.java
+++ b/src/main/kotlin/com/example/front/dashboard/service/DashboardService.java
@@ -30,7 +30,7 @@ public class DashboardService {
     }
 
     /*public List<AirData> GetAirData(DashboardSearchDto dto){
-
+        airDataResponse.getList()
     }*/
 
     public void ValidDashboardSearch(DashboardSearchDto dto){

--- a/src/main/kotlin/com/example/front/dashboard/service/LocalType.java
+++ b/src/main/kotlin/com/example/front/dashboard/service/LocalType.java
@@ -2,33 +2,29 @@ package com.example.front.dashboard.service;
 
 public enum LocalType {
 
-    Seoul("서울","SU"),
-    Busan("부산","BS"),
-    Daegu("부산","DG"),
-    Incheon("부산","IC"),
-    Gwangju("부산","GJ"),
-    Daejeon("대전","DJ"),
-    Ulsan("울산","US"),
-    Sejong("세종","SJ"),
-    Gyeonggido("경기도","GGD"),
-    Gangwon("강원","GW"),
-    Chungbuk("충북","CB"),
-    Chungnam("층남","CN"),
-    Jeonbuk("전북","JB"),
-    Jeonnam("전남","JN"),
-    Gyeongbuk("경북","GB"),
-    Gyeongnam("경남","GN"),
-    Jeju("제주","JJ");
+    Seoul("서울"),
+    Busan("부산"),
+    Daegu("대구"),
+    Incheon("부산"),
+    Gwangju("광주"),
+    Daejeon("대전"),
+    Ulsan("울산"),
+    Sejong("세종"),
+    Gyeonggido("경기도"),
+    Gangwon("강원"),
+    Chungbuk("충북"),
+    Chungnam("층남"),
+    Jeonbuk("전북"),
+    Jeonnam("전남"),
+    Gyeongbuk("경북"),
+    Gyeongnam("경남"),
+    Jeju("제주");
 
     private String localName;
-    private String localCode;
 
-    LocalType(String localName,String localCode){
+    LocalType(String localName){
         this.localName = localName;
-        this.localCode = localCode;
     }
 
     public String getLocalName(){return localName;}
-
-    public String getLocalCode(){return localCode;}
 }


### PR DESCRIPTION
Map 타입으로 받았던 parms 을 구체적인 dto 클래스로 변경하여 유지보수성 개선
map타입의 경우 개발시 사용시 편리하지만 map안에 어떤 데이터를 가지고 잇는지 바로 확인이 어려워 유지보수성이 떨어짐

Map타입을 제거하면 추상클래스의 타입도 T 제네릭으로 처리하여 상황에 맞는 dto 클래스 받을 수 있게 변경